### PR TITLE
Using `SYMBOL_P` macro

### DIFF
--- a/ext/win32ole/win32ole.c
+++ b/ext/win32ole/win32ole.c
@@ -2542,7 +2542,7 @@ hash2named_arg(VALUE key, VALUE val, VALUE pop)
     /*---------------------------------------------
       the data-type of key must be String or Symbol
     -----------------------------------------------*/
-    if(!RB_TYPE_P(key, T_STRING) && !RB_TYPE_P(key, T_SYMBOL)) {
+    if(!RB_TYPE_P(key, T_STRING) && !SYMBOL_P(key)) {
         /* clear name of dispatch parameters */
         for(i = 1; i < index + 1; i++) {
             SysFreeString(pOp->pNamedArgs[i]);
@@ -2554,7 +2554,7 @@ hash2named_arg(VALUE key, VALUE val, VALUE pop)
         /* raise an exception */
         rb_raise(rb_eTypeError, "wrong argument type (expected String or Symbol)");
     }
-    if (RB_TYPE_P(key, T_SYMBOL)) {
+    if (SYMBOL_P(key)) {
 	key = rb_sym2str(key);
     }
 
@@ -2618,10 +2618,10 @@ ole_invoke(int argc, VALUE *argv, VALUE self, USHORT wFlags, BOOL is_bracket)
     op.dp.cArgs = 0;
 
     rb_scan_args(argc, argv, "1*", &cmd, &paramS);
-    if(!RB_TYPE_P(cmd, T_STRING) && !RB_TYPE_P(cmd, T_SYMBOL) && !is_bracket) {
+    if(!RB_TYPE_P(cmd, T_STRING) && !SYMBOL_P(cmd) && !is_bracket) {
 	rb_raise(rb_eTypeError, "method is wrong type (expected String or Symbol)");
     }
-    if (RB_TYPE_P(cmd, T_SYMBOL)) {
+    if (SYMBOL_P(cmd)) {
 	cmd = rb_sym2str(cmd);
     }
     pole = oledata_get_struct(self);
@@ -3630,10 +3630,10 @@ fole_respond_to(VALUE self, VALUE method)
     BSTR wcmdname;
     DISPID DispID;
     HRESULT hr;
-    if(!RB_TYPE_P(method, T_STRING) && !RB_TYPE_P(method, T_SYMBOL)) {
+    if(!RB_TYPE_P(method, T_STRING) && !SYMBOL_P(method)) {
         rb_raise(rb_eTypeError, "wrong argument type (expected String or Symbol)");
     }
-    if (RB_TYPE_P(method, T_SYMBOL)) {
+    if (SYMBOL_P(method)) {
         method = rb_sym2str(method);
     }
     pole = oledata_get_struct(self);

--- a/ext/win32ole/win32ole_event.c
+++ b/ext/win32ole/win32ole_event.c
@@ -1038,10 +1038,10 @@ ev_on_event(int argc, VALUE *argv, VALUE self, VALUE is_ary_arg)
     }
     rb_scan_args(argc, argv, "01*", &event, &args);
     if(!NIL_P(event)) {
-        if(!RB_TYPE_P(event, T_STRING) && !RB_TYPE_P(event, T_SYMBOL)) {
+        if(!RB_TYPE_P(event, T_STRING) && !SYMBOL_P(event)) {
             rb_raise(rb_eTypeError, "wrong argument type (expected String or Symbol)");
         }
-        if (RB_TYPE_P(event, T_SYMBOL)) {
+        if (SYMBOL_P(event)) {
             event = rb_sym2str(event);
         }
     }
@@ -1128,10 +1128,10 @@ fev_off_event(int argc, VALUE *argv, VALUE self)
 
     rb_scan_args(argc, argv, "01", &event);
     if(!NIL_P(event)) {
-        if(!RB_TYPE_P(event, T_STRING) && !RB_TYPE_P(event, T_SYMBOL)) {
+        if(!RB_TYPE_P(event, T_STRING) && !SYMBOL_P(event)) {
             rb_raise(rb_eTypeError, "wrong argument type (expected String or Symbol)");
         }
-        if (RB_TYPE_P(event, T_SYMBOL)) {
+        if (SYMBOL_P(event)) {
             event = rb_sym2str(event);
         }
     }

--- a/ext/win32ole/win32ole_record.c
+++ b/ext/win32ole/win32ole_record.c
@@ -284,10 +284,10 @@ folerecord_initialize(VALUE self, VALUE typename, VALUE oleobj) {
     ITypeLib *pTypeLib = NULL;
     IRecordInfo *pri = NULL;
 
-    if (!RB_TYPE_P(typename, T_STRING) && !RB_TYPE_P(typename, T_SYMBOL)) {
+    if (!RB_TYPE_P(typename, T_STRING) && !SYMBOL_P(typename)) {
         rb_raise(rb_eArgError, "1st argument should be String or Symbol");
     }
-    if (RB_TYPE_P(typename, T_SYMBOL)) {
+    if (SYMBOL_P(typename)) {
         typename = rb_sym2str(typename);
     }
 
@@ -503,11 +503,11 @@ static VALUE
 folerecord_ole_instance_variable_get(VALUE self, VALUE name)
 {
     VALUE sname;
-    if(!RB_TYPE_P(name, T_STRING) && !RB_TYPE_P(name, T_SYMBOL)) {
+    if(!RB_TYPE_P(name, T_STRING) && !SYMBOL_P(name)) {
         rb_raise(rb_eTypeError, "wrong argument type (expected String or Symbol)");
     }
     sname = name;
-    if (RB_TYPE_P(name, T_SYMBOL)) {
+    if (SYMBOL_P(name)) {
         sname = rb_sym2str(name);
     }
     return olerecord_ivar_get(self, sname);
@@ -542,11 +542,11 @@ static VALUE
 folerecord_ole_instance_variable_set(VALUE self, VALUE name, VALUE val)
 {
     VALUE sname;
-    if(!RB_TYPE_P(name, T_STRING) && !RB_TYPE_P(name, T_SYMBOL)) {
+    if(!RB_TYPE_P(name, T_STRING) && !SYMBOL_P(name)) {
         rb_raise(rb_eTypeError, "wrong argument type (expected String or Symbol)");
     }
     sname = name;
-    if (RB_TYPE_P(name, T_SYMBOL)) {
+    if (SYMBOL_P(name)) {
         sname = rb_sym2str(name);
     }
     return olerecord_ivar_set(self, sname, val);


### PR DESCRIPTION
Some code has these code.

```c
if (RB_TYPE_P(event, T_SYMBOL)) {
    event = rb_sym2str(event);
}
```

But, `SYMBOL_P` macro was defined in `include/ruby/internal/value_type.h`.
I think better to using `SYMBOL_P` instead of `RB_TYPE_P`.
