### PR TITLE
Alias the top-level WIN32OLE_* classes

### DIFF
--- a/ext/win32ole/win32ole_event.c
+++ b/ext/win32ole/win32ole_event.c
@@ -1264,7 +1264,8 @@ Init_win32ole_event(void)
     ary_ole_event = rb_ary_new();
     rb_gc_register_mark_object(ary_ole_event);
     id_events = rb_intern("events");
-    cWIN32OLE_EVENT = rb_define_class("WIN32OLE_EVENT", rb_cObject);
+    cWIN32OLE_EVENT = rb_define_class_under(cWIN32OLE, "Event", rb_cObject);
+    rb_define_const(rb_cObject, "WIN32OLE_EVENT", cWIN32OLE_EVENT);
     rb_define_singleton_method(cWIN32OLE_EVENT, "message_loop", fev_s_msg_loop, 0);
     rb_define_alloc_func(cWIN32OLE_EVENT, fev_s_allocate);
     rb_define_method(cWIN32OLE_EVENT, "initialize", fev_initialize, -1);

--- a/ext/win32ole/win32ole_method.c
+++ b/ext/win32ole/win32ole_method.c
@@ -927,7 +927,8 @@ VALUE cWIN32OLE_METHOD;
 
 void Init_win32ole_method(void)
 {
-    cWIN32OLE_METHOD = rb_define_class("WIN32OLE_METHOD", rb_cObject);
+    cWIN32OLE_METHOD = rb_define_class_under(cWIN32OLE, "Method", rb_cObject);
+    rb_define_const(rb_cObject, "WIN32OLE_METHOD", cWIN32OLE_METHOD);
     rb_define_alloc_func(cWIN32OLE_METHOD, folemethod_s_allocate);
     rb_define_method(cWIN32OLE_METHOD, "initialize", folemethod_initialize, 2);
     rb_define_method(cWIN32OLE_METHOD, "name", folemethod_name, 0);

--- a/ext/win32ole/win32ole_param.c
+++ b/ext/win32ole/win32ole_param.c
@@ -422,7 +422,8 @@ foleparam_inspect(VALUE self)
 void
 Init_win32ole_param(void)
 {
-    cWIN32OLE_PARAM = rb_define_class("WIN32OLE_PARAM", rb_cObject);
+    cWIN32OLE_PARAM = rb_define_class_under(cWIN32OLE, "Param", rb_cObject);
+    rb_define_const(rb_cObject, "WIN32OLE_PARAM", cWIN32OLE_PARAM);
     rb_define_alloc_func(cWIN32OLE_PARAM, foleparam_s_allocate);
     rb_define_method(cWIN32OLE_PARAM, "initialize", foleparam_initialize, 2);
     rb_define_method(cWIN32OLE_PARAM, "name", foleparam_name, 0);

--- a/ext/win32ole/win32ole_record.c
+++ b/ext/win32ole/win32ole_record.c
@@ -594,7 +594,8 @@ VALUE cWIN32OLE_RECORD;
 void
 Init_win32ole_record(void)
 {
-    cWIN32OLE_RECORD = rb_define_class("WIN32OLE_RECORD", rb_cObject);
+    cWIN32OLE_RECORD = rb_define_class_under(cWIN32OLE, "Record", rb_cObject);
+    rb_define_const(rb_cObject, "WIN32OLE_RECORD", cWIN32OLE_RECORD);
     rb_define_alloc_func(cWIN32OLE_RECORD, folerecord_s_allocate);
     rb_define_method(cWIN32OLE_RECORD, "initialize", folerecord_initialize, 2);
     rb_define_method(cWIN32OLE_RECORD, "to_h", folerecord_to_h, 0);

--- a/ext/win32ole/win32ole_type.c
+++ b/ext/win32ole/win32ole_type.c
@@ -887,7 +887,8 @@ VALUE cWIN32OLE_TYPE;
 
 void Init_win32ole_type(void)
 {
-    cWIN32OLE_TYPE = rb_define_class("WIN32OLE_TYPE", rb_cObject);
+    cWIN32OLE_TYPE = rb_define_class_under(cWIN32OLE, "Type", rb_cObject);
+    rb_define_const(rb_cObject, "WIN32OLE_TYPE", cWIN32OLE_TYPE);
     rb_define_singleton_method(cWIN32OLE_TYPE, "ole_classes", foletype_s_ole_classes, 1);
     rb_define_singleton_method(cWIN32OLE_TYPE, "typelibs", foletype_s_typelibs, 0);
     rb_define_singleton_method(cWIN32OLE_TYPE, "progids", foletype_s_progids, 0);

--- a/ext/win32ole/win32ole_typelib.c
+++ b/ext/win32ole/win32ole_typelib.c
@@ -827,7 +827,8 @@ VALUE cWIN32OLE_TYPELIB;
 void
 Init_win32ole_typelib(void)
 {
-    cWIN32OLE_TYPELIB = rb_define_class("WIN32OLE_TYPELIB", rb_cObject);
+    cWIN32OLE_TYPELIB = rb_define_class_under(cWIN32OLE, "Typelib", rb_cObject);
+    rb_define_const(rb_cObject, "WIN32OLE_TYPELIB", cWIN32OLE_TYPELIB);
     rb_define_singleton_method(cWIN32OLE_TYPELIB, "typelibs", foletypelib_s_typelibs, 0);
     rb_define_alloc_func(cWIN32OLE_TYPELIB, foletypelib_s_allocate);
     rb_define_method(cWIN32OLE_TYPELIB, "initialize", foletypelib_initialize, -2);

--- a/ext/win32ole/win32ole_variable.c
+++ b/ext/win32ole/win32ole_variable.c
@@ -369,7 +369,8 @@ VALUE cWIN32OLE_VARIABLE;
 
 void Init_win32ole_variable(void)
 {
-    cWIN32OLE_VARIABLE = rb_define_class("WIN32OLE_VARIABLE", rb_cObject);
+    cWIN32OLE_VARIABLE = rb_define_class_under(cWIN32OLE, "Variable", rb_cObject);
+    rb_define_const(rb_cObject, "WIN32OLE_VARIABLE", cWIN32OLE_VARIABLE);
     rb_undef_alloc_func(cWIN32OLE_VARIABLE);
     rb_define_method(cWIN32OLE_VARIABLE, "name", folevariable_name, 0);
     rb_define_method(cWIN32OLE_VARIABLE, "ole_type", folevariable_ole_type, 0);

--- a/ext/win32ole/win32ole_variant.c
+++ b/ext/win32ole/win32ole_variant.c
@@ -695,7 +695,8 @@ void
 Init_win32ole_variant(void)
 {
 #undef rb_intern
-    cWIN32OLE_VARIANT = rb_define_class("WIN32OLE_VARIANT", rb_cObject);
+    cWIN32OLE_VARIANT = rb_define_class_under(cWIN32OLE, "Variant", rb_cObject);
+    rb_define_const(rb_cObject, "WIN32OLE_VARIANT", cWIN32OLE_VARIANT);
     rb_define_alloc_func(cWIN32OLE_VARIANT, folevariant_s_allocate);
     rb_define_singleton_method(cWIN32OLE_VARIANT, "array", folevariant_s_array, 2);
     rb_define_method(cWIN32OLE_VARIANT, "initialize", folevariant_initialize, -2);


### PR DESCRIPTION
`WIN32OLE` defines some of the top-level classes which are prefixed and seem be better off under this namespace.
In the future, it might be better to move to the new names gradually, I guess.