### PR TITLE
Fix nil reference issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 /tmp/
 /logs/
 ChangeLog
+
+/Gemfile.lock
+ext/*/Makefile
+ext/*/*.log
+lib/**/*/*.so

--- a/test/win32ole/test_win32ole_event.rb
+++ b/test/win32ole/test_win32ole_event.rb
@@ -77,7 +77,11 @@ if defined?(WIN32OLE::Event)
       end
 
       def default_handler(event, *args)
-        @event += event
+        if @event
+          @event += event
+        else
+          @event = event
+        end
       end
 
       def handler1


### PR DESCRIPTION
I'm not sure why that's happend.

https://github.com/ruby/win32ole/actions/runs/14320550876/job/40136434242?pr=39

The all of versions failed this nil reference error. I added simple workaround for that test.